### PR TITLE
Updates to make this compatible with recent versions of Node.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.swp
+node_modules/

--- a/apptest.js
+++ b/apptest.js
@@ -1,13 +1,19 @@
-var fcgiApp = require("./fcgi"),
-	http = require("http");
+#!/usr/bin/env node
+var fcgiApp = require('./index'),
+    http = require('http'),
+    net = require('net');
 
-var myServer = http.createServer(function(req, res) {
-	res.writeHead(200, {"Content-type": "text/html"});
-	res.end("It works! :) " + Date.now() + "<pre>" + require("util").inspect(req) + "</pre>");
-});
+var app = function (req, res) {
+  res.writeHead(200, {'Content-type': 'text/html'});
+  res.end('It works! :) ' + Date.now() + '<pre>' + require('util').inspect(req) + '</pre>');
+}
 
 // Instead of this:
+//var myServer = http.createServer(app);
 //myServer.listen(12345);
 
 // You do this:
-fcgiApp.handle(myServer);
+var myServer = net.createServer(fcgiApp(app));
+myServer.listen({fd: process.stdin.fd});
+// OR (depending on webserver configuration)
+//myServer.listen(1666);

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./fcgi').handle;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "node-fastcgi-application",
+  "version": "0.1.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "mocha test/"
+  },
+  "dependencies": {
+    "fastcgi-stream": "^0.1.3"
+  },
+  "devDependencies": {
+    "mocha": "^2.3.3",
+    "should": "^7.1.1"
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,122 @@
+"use strict";
+var fastcgi = require('fastcgi-stream');
+var fs = require('fs');
+var net = require('net');
+var path = require('path');
+var should = require('should');
+
+var fcgiApp = require('../index');
+
+var SOCK = path.join(__dirname, './test.sock');
+
+describe('FastCGI application tests', function () {
+  beforeEach(function (done) {
+    fs.exists(SOCK, function (exists) {
+      if (exists) {
+        fs.unlink(SOCK, done);
+      } else {
+        done();
+      }
+    });
+  });
+
+  it('should set headers and environment variables on the request', function (done) {
+    var server = net.createServer(fcgiApp(function (req, res) {
+      should(req.env).be.ok();
+      req.env.should.have.property('remote-user');
+      req.env['remote-user'].should.eql('user-env');
+
+      should(req.headers).be.ok();
+      req.headers.should.have.property('remote-user');
+      req.headers['remote-user'].should.equal('user-header');
+
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end();
+    }));
+    server.listen(SOCK);
+
+    var client = net.connect({ path: SOCK }, function () { });
+    var fcgiStream = new fastcgi.FastCGIStream(client);
+
+    var requestId = 1;
+    fcgiStream.writeRecord(requestId, new fastcgi.records.BeginRequest(
+      fastcgi.records.BeginRequest.roles.RESPONDER,
+      fastcgi.records.BeginRequest.flags.KEEP_CONN
+    ));
+
+    fcgiStream.writeRecord(requestId, new fastcgi.records.Params([
+      ['REMOTE_USER', 'user-env'],
+      ['HTTP_REMOTE_USER', 'user-header']
+    ]));
+    fcgiStream.writeRecord(requestId, new fastcgi.records.Params([]));
+    fcgiStream.writeRecord(requestId, new fastcgi.records.StdIn(''));
+    client.end();
+
+    // Consume the response.
+    fcgiStream.on('record', function (requestId, record) {
+      should(requestId).be.eql(1);
+
+      if (requestId !== fastcgi.constants.NULL_REQUEST_ID) {
+        switch (record.TYPE) {
+          case fastcgi.records.EndRequest.TYPE: {
+            server.close(done);
+            break;
+          }
+        }
+      }
+    });
+  });
+
+  it('should set request attributes based on common environment variables', function (done) {
+    var server = net.createServer(fcgiApp(function (req, res) {
+      should(req.env).be.ok();
+
+      should(req.httpVersionMinor).be.eql(1);
+      should(req.httpVersionMajor).be.eql(1);
+      should(req.httpVersion).be.eql('1.1');
+
+      should(req.url).be.eql('/');
+      should(req.method).be.eql('GET');
+      should(req.connection.encrypted).be.eql(true);
+      should(req.connection.remoteAddress).be.eql('192.168.1.100');
+
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end();
+    }));
+    server.listen(SOCK);
+
+    var client = net.connect({ path: SOCK }, function () { });
+    var fcgiStream = new fastcgi.FastCGIStream(client);
+
+    var requestId = 1;
+    fcgiStream.writeRecord(requestId, new fastcgi.records.BeginRequest(
+      fastcgi.records.BeginRequest.roles.RESPONDER,
+      fastcgi.records.BeginRequest.flags.KEEP_CONN
+    ));
+
+    fcgiStream.writeRecord(requestId, new fastcgi.records.Params([
+      ['SERVER_PROTOCOL', 'HTTP/1.1'],
+      ['REQUEST_URI', '/'],
+      ['REQUEST_METHOD', 'GET'],
+      ['REQUEST_SCHEME', 'https'],
+      ['REMOTE_ADDR', '192.168.1.100']
+    ]));
+    fcgiStream.writeRecord(requestId, new fastcgi.records.Params([]));
+    fcgiStream.writeRecord(requestId, new fastcgi.records.StdIn(''));
+    client.end();
+
+    // Consume the response.
+    fcgiStream.on('record', function (requestId, record) {
+      should(requestId).be.eql(1);
+
+      if (requestId !== fastcgi.constants.NULL_REQUEST_ID) {
+        switch (record.TYPE) {
+          case fastcgi.records.EndRequest.TYPE: {
+            server.close(done);
+            break;
+          }
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
I have a need to use a Node.js app behind Apache's mod_proxy_fcgi due to another Apache plugin that passes certain properties as FastCGI env variables.
So, I made some updates to get this working with recent versions of node, fixed some bugs, and added a few tests along the way.
I think this should be made available on npm too! :)

Thanks,
-Roman